### PR TITLE
Adapted the plugin to the latest version of checkstyle

### DIFF
--- a/data/default-checkstyle.xml
+++ b/data/default-checkstyle.xml
@@ -1,151 +1,198 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
-    This configuration file was written by the eclipse-cs plugin configuration editor
+
+  Checkstyle configuration that checks the sun coding conventions from:
+
+    - the Java Language Specification at
+      https://docs.oracle.com/javase/specs/jls/se11/html/index.html
+
+    - the Sun Code Conventions at https://www.oracle.com/technetwork/java/codeconvtoc-136057.html
+
+    - the Javadoc guidelines at
+      https://www.oracle.com/technetwork/java/javase/documentation/index-137868.html
+
+    - the JDK Api documentation https://docs.oracle.com/en/java/javase/11/
+
+    - some best practices
+
+  Checkstyle is very configurable. Be sure to read the documentation at
+  https://checkstyle.org (or in your downloaded distribution).
+
+  Most Checks are configurable, be sure to consult the documentation.
+
+  To completely disable a check, just comment it out or delete it from the file.
+  To suppress certain violations please review suppression filters.
+
+  Finally, it is worth reading the documentation.
+
 -->
-<!--
-    Checkstyle-Configuration: vfh
-    Checkstyle Version: 6.4.0
-    Description: none
--->
+
 <module name="Checker">
-  <property name="severity" value="warning"/>
-  <module name="TreeWalker">
-    <property name="tabWidth" value="4"/>
-    <module name="JavadocMethod">
-      <property name="suppressLoadErrors" value="true"/>
+    <!--
+        If you set the basedir property below, then all reported file
+        names will be relative to the specified directory. See
+        https://checkstyle.org/5.x/config.html#Checker
+
+        <property name="basedir" value="${basedir}"/>
+    -->
+    <property name="severity" value="error"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+
+    <!-- Excludes all 'module-info.java' files              -->
+    <!-- See https://checkstyle.org/config_filefilters.html -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
     </module>
-    <module name="JavadocType"/>
-    <module name="JavadocVariable"/>
-    <module name="JavadocStyle"/>
-    <module name="ConstantName"/>
-    <module name="LocalFinalVariableName"/>
-    <module name="LocalVariableName"/>
-    <module name="MemberName"/>
-    <module name="MethodName"/>
-    <module name="PackageName"/>
-    <module name="ParameterName"/>
-    <module name="StaticVariableName"/>
-    <module name="TypeName"/>
-    <module name="IllegalImport"/>
-    <module name="UnusedImports"/>
-    <module name="MethodLength"/>
-    <module name="ParameterNumber"/>
-    <module name="EmptyForIteratorPad">
-      <property name="option" value="space"/>
+
+    <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
+                  default="checkstyle-suppressions.xml" />
+        <property name="optional" value="true"/>
     </module>
-    <module name="MethodParamPad"/>
-    <module name="NoWhitespaceAfter"/>
-    <module name="NoWhitespaceBefore"/>
-    <module name="OperatorWrap"/>
-    <module name="ParenPad"/>
-    <module name="TypecastParenPad"/>
-    <module name="WhitespaceAfter"/>
-    <module name="WhitespaceAround"/>
-    <module name="AvoidNestedBlocks"/>
-    <module name="EmptyBlock"/>
-    <module name="LeftCurly"/>
-    <module name="NeedBraces"/>
-    <module name="RightCurly"/>
-    <module name="MissingSwitchDefault">
-      <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Sollte aus Sicherheitsgründen drin bleiben"/>
-    </module>
+
+    <!-- Checks that a package-info.java file exists for each package.     -->
+    <!-- See https://checkstyle.org/config_javadoc.html#JavadocPackage -->
+    <module name="JavadocPackage"/>
+
+    <!-- Checks whether files end with a new line.                        -->
+    <!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
+    <module name="NewlineAtEndOfFile"/>
+
+    <!-- Checks that property files contain the same keys.         -->
+    <!-- See https://checkstyle.org/config_misc.html#Translation -->
+    <module name="Translation"/>
+
+    <!-- Checks for Size Violations.                    -->
+    <!-- See https://checkstyle.org/config_sizes.html -->
+    <module name="FileLength"/>
     <module name="LineLength">
-      <property name="max" value="100"/>
-      <property name="tabWidth" value="4"/>
+      <property name="fileExtensions" value="java"/>
     </module>
-    <module name="Indentation">
-      <property name="caseIndent" value="0"/>
+
+    <!-- Checks for whitespace                               -->
+    <!-- See https://checkstyle.org/config_whitespace.html -->
+    <module name="FileTabCharacter"/>
+
+    <!-- Miscellaneous other checks.                   -->
+    <!-- See https://checkstyle.org/config_misc.html -->
+    <module name="RegexpSingleline">
+       <property name="format" value="\s+$"/>
+       <property name="minimum" value="0"/>
+       <property name="maximum" value="0"/>
+       <property name="message" value="Line has trailing spaces."/>
     </module>
-    <module name="ModifierOrder"/>
-    <module name="RedundantModifier"/>
-    <module name="SuperFinalize"/>
-    <module name="ArrayTrailingComma"/>
-    <module name="UnnecessaryParentheses"/>
-    <module name="DefaultComesLast"/>
-    <module name="DeclarationOrder"/>
-    <module name="EmptyStatement"/>
-    <module name="FallThrough">
-      <property name="severity" value="info"/>
+
+    <!-- Checks for Headers                                -->
+    <!-- See https://checkstyle.org/config_header.html   -->
+    <!-- <module name="Header"> -->
+    <!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
+    <!--   <property name="fileExtensions" value="java"/> -->
+    <!-- </module> -->
+
+    <module name="TreeWalker">
+
+        <!-- Checks for Javadoc comments.                     -->
+        <!-- See https://checkstyle.org/config_javadoc.html -->
+        <module name="InvalidJavadocPosition"/>
+        <module name="JavadocMethod"/>
+        <module name="JavadocType"/>
+        <module name="JavadocVariable"/>
+        <module name="JavadocStyle"/>
+        <module name="MissingJavadocMethod"/>
+
+        <!-- Checks for Naming Conventions.                  -->
+        <!-- See https://checkstyle.org/config_naming.html -->
+        <module name="ConstantName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
+        <module name="MemberName"/>
+        <module name="MethodName"/>
+        <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName"/>
+
+        <!-- Checks for imports                              -->
+        <!-- See https://checkstyle.org/config_import.html -->
+        <module name="AvoidStarImport"/>
+        <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+        <module name="RedundantImport"/>
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="false"/>
+        </module>
+
+        <!-- Checks for Size Violations.                    -->
+        <!-- See https://checkstyle.org/config_sizes.html -->
+        <module name="MethodLength"/>
+        <module name="ParameterNumber"/>
+
+        <!-- Checks for whitespace                               -->
+        <!-- See https://checkstyle.org/config_whitespace.html -->
+        <module name="EmptyForIteratorPad"/>
+        <module name="GenericWhitespace"/>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceAfter"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="OperatorWrap"/>
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+
+        <!-- Modifier Checks                                    -->
+        <!-- See https://checkstyle.org/config_modifiers.html -->
+        <module name="ModifierOrder"/>
+        <module name="RedundantModifier"/>
+
+        <!-- Checks for blocks. You know, those {}'s         -->
+        <!-- See https://checkstyle.org/config_blocks.html -->
+        <module name="AvoidNestedBlocks"/>
+        <module name="EmptyBlock"/>
+        <module name="LeftCurly"/>
+        <module name="NeedBraces"/>
+        <module name="RightCurly"/>
+
+        <!-- Checks for common coding problems               -->
+        <!-- See https://checkstyle.org/config_coding.html -->
+        <module name="EmptyStatement"/>
+        <module name="EqualsHashCode"/>
+        <module name="HiddenField"/>
+        <module name="IllegalInstantiation"/>
+        <module name="InnerAssignment"/>
+        <module name="MagicNumber"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+
+        <!-- Checks for class design                         -->
+        <!-- See https://checkstyle.org/config_design.html -->
+        <module name="DesignForExtension"/>
+        <module name="FinalClass"/>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="InterfaceIsType"/>
+        <module name="VisibilityModifier"/>
+
+        <!-- Miscellaneous other checks.                   -->
+        <!-- See https://checkstyle.org/config_misc.html -->
+        <module name="ArrayTypeStyle"/>
+        <module name="FinalParameters"/>
+        <module name="TodoComment"/>
+        <module name="UpperEll"/>
+
+        <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+        <module name="SuppressionXpathFilter">
+            <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
+                      default="checkstyle-xpath-suppressions.xml" />
+            <property name="optional" value="true"/>
+        </module>
+
     </module>
-    <module name="HiddenField">
-      <property name="severity" value="info"/>
-    </module>
-    <module name="MagicNumber">
-      <property name="severity" value="info"/>
-    </module>
-    <module name="MultipleVariableDeclarations"/>
-    <module name="SimplifyBooleanExpression"/>
-    <module name="SimplifyBooleanReturn"/>
-    <module name="StringLiteralEquality"/>
-    <module name="UpperEll">
-      <property name="severity" value="info"/>
-    </module>
-    <module name="ArrayTypeStyle"/>
-    <module name="GenericWhitespace"/>
-    <module name="EmptyForInitializerPad">
-      <property name="option" value="space"/>
-    </module>
-    <module name="ClassTypeParameterName"/>
-    <module name="MethodTypeParameterName"/>
-    <module name="IllegalCatch">
-      <property name="severity" value="info"/>
-    </module>
-    <module name="IllegalThrows">
-      <property name="severity" value="info"/>
-    </module>
-    <module name="InnerAssignment">
-      <property name="severity" value="info"/>
-    </module>
-    <module name="ModifiedControlVariable">
-      <property name="severity" value="info"/>
-    </module>
-    <module name="MultipleStringLiterals">
-      <property name="severity" value="ignore"/>
-      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
-    </module>
-    <module name="NestedIfDepth">
-      <property name="severity" value="info"/>
-      <property name="max" value="2"/>
-    </module>
-    <module name="NestedTryDepth">
-      <property name="severity" value="info"/>
-      <property name="max" value="2"/>
-    </module>
-    <module name="ParameterAssignment">
-      <property name="severity" value="info"/>
-    </module>
-<!--    <module name="RedundantThrows">
-      <property name="severity" value="ignore"/>
-      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="info"/>
-    </module> -->
-    <module name="ReturnCount">
-      <property name="severity" value="info"/>
-    </module>
-    <module name="SuperClone">
-      <property name="severity" value="info"/>
-    </module>
-    <module name="CovariantEquals">
-      <property name="severity" value="info"/>
-    </module>
-    <module name="EqualsAvoidNull">
-      <property name="severity" value="info"/>
-    </module>
-    <module name="EqualsHashCode">
-      <property name="severity" value="info"/>
-    </module>
-    <module name="ExplicitInitialization">
-      <property name="severity" value="info"/>
-    </module>
-<!--    <module name="StrictDuplicateCode">
-      <property name="severity" value="ignore"/>
-      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
-    </module> -->
-  </module>
-<!--  <module name="NewlineAtEndOfFile">
-    <property name="severity" value="info"/>
-  </module> -->
-  <module name="FileTabCharacter"/>
-  <module name="FileLength"/>
+
 </module>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linter-checkstyle",
   "main": "./lib/init",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Lint java using checkstyle",
   "repository": "https://github.com/SebastianSzturo/linter-checkstyle",
   "license": "MIT",


### PR DESCRIPTION
- Updated the default XML checks file to comply to checkstyle 8.30+
- Changed the regex to match the new output format of checkstyle
- Added the column number when available
- Updated version from 1.2.0 to 1.3.0 (but you can change that)